### PR TITLE
Pin supervisord for Python 2.6

### DIFF
--- a/prestodb/centos6-oj8/Dockerfile
+++ b/prestodb/centos6-oj8/Dockerfile
@@ -52,7 +52,7 @@ RUN \
     yum install -y python-pip && \
     pip install --upgrade pip==9.0.3 `# latest version for Python 2.6` && \
     pip install --upgrade setuptools==36.8.0 `# latest version for Python 2.6` && \
-    pip install supervisor && \
+    pip install supervisor==3.4.0 && \
     \
     # install commonly needed packages
     yum install -y \


### PR DESCRIPTION
`supervisord` drop support for Python 2.6 in
https://github.com/Supervisor/supervisor/pull/1029