### PR TITLE
Fix Metastore get_fields in HDP 3.1

### DIFF
--- a/prestodev/hdp3.1-hive-kerberized/files/etc/hive/conf/hive-site.xml
+++ b/prestodev/hdp3.1-hive-kerberized/files/etc/hive/conf/hive-site.xml
@@ -65,6 +65,12 @@
     </property>
 
     <property>
+        <!-- https://community.hortonworks.com/content/supportkb/247055/errorjavalangunsupportedoperationexception-storage.html -->
+        <name>metastore.storage.schema.reader.impl</name>
+        <value>org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader</value>
+    </property>
+
+    <property>
         <name>hive.support.concurrency</name>
         <value>true</value>
     </property>

--- a/prestodev/hdp3.1-hive/files/etc/hive/conf/hive-site.xml
+++ b/prestodev/hdp3.1-hive/files/etc/hive/conf/hive-site.xml
@@ -65,6 +65,12 @@
     </property>
 
     <property>
+        <!-- https://community.hortonworks.com/content/supportkb/247055/errorjavalangunsupportedoperationexception-storage.html -->
+        <name>metastore.storage.schema.reader.impl</name>
+        <value>org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader</value>
+    </property>
+
+    <property>
         <name>hive.support.concurrency</name>
         <value>true</value>
     </property>


### PR DESCRIPTION
Without the change, the call fails with

```
MetaException: java.lang.UnsupportedOperationException: Storage schema reading not supported
```