### PR TITLE
Fix got only one bucket file

### DIFF
--- a/prestodev/hdp3.1-hive/files/etc/tez/conf/tez-site.xml
+++ b/prestodev/hdp3.1-hive/files/etc/tez/conf/tez-site.xml
@@ -42,10 +42,6 @@
         <value>8</value>
     </property>
     <property>
-        <name>tez.shuffle-vertex-manager.enable.auto-parallel</name>
-        <value>true</value>
-    </property>
-    <property>
         <name>tez.am.max.app.attempts</name>
         <value>1</value>
     </property>


### PR DESCRIPTION
Fix by remoring this property(default value is `false`)
```xml 
   <property>
        <name>tez.shuffle-vertex-manager.enable.auto-parallel</name>
        <value>true</value>
    </property>
```
![Snipaste_2019-08-07_20-17-19](https://user-images.githubusercontent.com/20929338/62622212-61bfe900-b950-11e9-8c60-ec95322698f7.png)

