### PR TITLE
Initiate information_schema, sys schemas in Hive

### DIFF
--- a/prestodev/cdh5.12-hive/files/root/setup.sh
+++ b/prestodev/cdh5.12-hive/files/root/setup.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
-# 0 make file system hostname resolvable
+# make file system hostname resolvable
 echo "127.0.0.1 hadoop-master" >> /etc/hosts
 
-# 1 format namenode
+# format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 
 # workaround for 'could not open session' bug as suggested here:
@@ -11,11 +11,11 @@ chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 rm -f /etc/security/limits.d/hdfs.conf
 su -c "echo 'N' | hdfs namenode -format" hdfs
 
-# 2 start hdfs
+# start hdfs
 su -c "hdfs datanode  2>&1 > /var/log/hadoop-hdfs/hadoop-hdfs-datanode.log" hdfs&
 su -c "hdfs namenode  2>&1 > /var/log/hadoop-hdfs/hadoop-hdfs-namenode.log" hdfs&
 
-# 3 wait for process starting
+# wait for process starting
 sleep 10
 
 # remove a broken symlink created by cdh installer so that init-hdfs.sh does no blow up on it
@@ -25,15 +25,15 @@ rm /usr/lib/hive/lib/hbase-annotations.jar
 # 4 exec cloudera hdfs init script
 /usr/lib/hadoop/libexec/init-hdfs.sh
 
-# 5 init hive directories
+# init hive directories
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -mkdir /user/hive/warehouse'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chmod 1777 /user/hive/warehouse'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chown hive /user/hive/warehouse'
 
-# 6 stop hdfs
+# stop hdfs
 killall java
 
-# 7 setup metastore
+# setup metastore
 mysql_install_db
 
 /usr/bin/mysqld_safe &

--- a/prestodev/cdh5.15-hive/files/root/setup.sh
+++ b/prestodev/cdh5.15-hive/files/root/setup.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
-# 0 make file system hostname resolvable
+# make file system hostname resolvable
 echo "127.0.0.1 hadoop-master" >> /etc/hosts
 
-# 1 format namenode
+# format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 
 # workaround for 'could not open session' bug as suggested here:
@@ -11,11 +11,11 @@ chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 rm -f /etc/security/limits.d/hdfs.conf
 su -c "echo 'N' | hdfs namenode -format" hdfs
 
-# 2 start hdfs
+# start hdfs
 su -c "hdfs datanode  2>&1 > /var/log/hadoop-hdfs/hadoop-hdfs-datanode.log" hdfs&
 su -c "hdfs namenode  2>&1 > /var/log/hadoop-hdfs/hadoop-hdfs-namenode.log" hdfs&
 
-# 3 wait for process starting
+# wait for process starting
 sleep 10
 
 # remove a broken symlink created by cdh installer so that init-hdfs.sh does no blow up on it
@@ -25,15 +25,15 @@ rm /usr/lib/hive/lib/hbase-annotations.jar
 # 4 exec cloudera hdfs init script
 /usr/lib/hadoop/libexec/init-hdfs.sh
 
-# 5 init hive directories
+# init hive directories
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -mkdir /user/hive/warehouse'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chmod 1777 /user/hive/warehouse'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chown hive /user/hive/warehouse'
 
-# 6 stop hdfs
+# stop hdfs
 killall java
 
-# 7 setup metastore
+# setup metastore
 mysql_install_db
 
 /usr/bin/mysqld_safe &

--- a/prestodev/hdp2.5-hive/files/root/setup.sh
+++ b/prestodev/hdp2.5-hive/files/root/setup.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
-# 0 make file system hostname resolvable
+# make file system hostname resolvable
 echo "127.0.0.1 hadoop-master" >> /etc/hosts
 
-# 1 format namenode
+# format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 
 # workaround for 'could not open session' bug as suggested here:
@@ -11,13 +11,13 @@ chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 rm -f /etc/security/limits.d/hdfs.conf
 su -c "echo 'N' | hdfs namenode -format" hdfs
 
-# 2 start hdfs
+# start hdfs
 su -c "hdfs namenode  2>&1 > /var/log/hadoop/hdfs/hadoop-hdfs-namenode.log" hdfs&
 
-# 3 wait for process starting
+# wait for process starting
 sleep 10
 
-# 4 init basic hdfs directories
+# init basic hdfs directories
 /usr/hdp/2.5.0.0-1245/hadoop/libexec/init-hdfs.sh
 
 # 4.1 Create an hdfs home directory for the yarn user. For some reason, init-hdfs doesn't do so.
@@ -26,17 +26,15 @@ su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chmod -R 1777 /tmp/hadoop-yarn'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -mkdir /tmp/hadoop-yarn/staging && /usr/bin/hadoop fs -chown mapred:mapred /tmp/hadoop-yarn/staging && /usr/bin/hadoop fs -chmod -R 1777 /tmp/hadoop-yarn/staging'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -mkdir /tmp/hadoop-yarn/staging/history && /usr/bin/hadoop fs -chown mapred:mapred /tmp/hadoop-yarn/staging/history && /usr/bin/hadoop fs -chmod -R 1777 /tmp/hadoop-yarn/staging/history'
 
-
-
-# 5 init hive directories
+# init hive directories
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -mkdir /user/hive/warehouse'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chmod 1777 /user/hive/warehouse'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chown hive /user/hive/warehouse'
 
-# 6 stop hdfs
+# stop hdfs
 killall java
 
-# 7 setup metastore
+# setup metastore
 mysql_install_db
 
 /usr/bin/mysqld_safe &

--- a/prestodev/hdp2.6-hive/files/root/setup.sh
+++ b/prestodev/hdp2.6-hive/files/root/setup.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
-# 0 make file system hostname resolvable
+# make file system hostname resolvable
 echo "127.0.0.1 hadoop-master" >> /etc/hosts
 
-# 1 format namenode
+# format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 
 # workaround for 'could not open session' bug as suggested here:
@@ -11,13 +11,13 @@ chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 rm -f /etc/security/limits.d/hdfs.conf
 su -c "echo 'N' | hdfs namenode -format" hdfs
 
-# 2 start hdfs
+# start hdfs
 su -c "hdfs namenode  2>&1 > /var/log/hadoop-hdfs/hadoop-hdfs-namenode.log" hdfs&
 
-# 3 wait for process starting
+# wait for process starting
 sleep 15
 
-# 4 init basic hdfs directories
+# init basic hdfs directories
 /usr/hdp/current/hadoop-client/libexec/init-hdfs.sh
 
 # 4.1 Create an hdfs home directory for the yarn user. For some reason, init-hdfs doesn't do so.
@@ -26,17 +26,15 @@ su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chmod -R 1777 /tmp/hadoop-yarn'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -mkdir /tmp/hadoop-yarn/staging && /usr/bin/hadoop fs -chown mapred:mapred /tmp/hadoop-yarn/staging && /usr/bin/hadoop fs -chmod -R 1777 /tmp/hadoop-yarn/staging'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -mkdir /tmp/hadoop-yarn/staging/history && /usr/bin/hadoop fs -chown mapred:mapred /tmp/hadoop-yarn/staging/history && /usr/bin/hadoop fs -chmod -R 1777 /tmp/hadoop-yarn/staging/history'
 
-
-
-# 5 init hive directories
+# init hive directories
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -mkdir /user/hive/warehouse'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chmod 1777 /user/hive/warehouse'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chown hive /user/hive/warehouse'
 
-# 6 stop hdfs
+# stop hdfs
 killall java
 
-# 7 setup metastore
+# setup metastore
 mysql_install_db
 
 /usr/bin/mysqld_safe &

--- a/prestodev/hdp3.1-hive/Dockerfile
+++ b/prestodev/hdp3.1-hive/Dockerfile
@@ -57,10 +57,6 @@ RUN rm -r /etc/hadoop/conf/* \
 # Copy configuration files
 COPY ./files /
 
-# Run setup script
-RUN /root/setup.sh \
-  && rm -rf /tmp/* /var/tmp/*
-
 # Setup sock proxy
 RUN yum install -y openssh openssh-clients openssh-server && yum -y clean all
 RUN ssh-keygen -t rsa -b 4096 -C "automation@prestosql.io" -N "" -f /root/.ssh/id_rsa \
@@ -69,6 +65,10 @@ RUN ssh-keygen -t rsa -b 4096 -C "automation@prestosql.io" -N "" -f /root/.ssh/i
   && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
 RUN chmod 755 /root && chmod 700 /root/.ssh
 RUN passwd --unlock root
+
+# Run setup script
+RUN /root/setup.sh \
+  && rm -rf /tmp/* /var/tmp/*
 
 # Provide convenience bash history
 RUN set -xeu; \

--- a/prestodev/hdp3.1-hive/files/root/setup.sh
+++ b/prestodev/hdp3.1-hive/files/root/setup.sh
@@ -58,5 +58,15 @@ sleep 10s
 mkdir /var/log/mysql/
 chown -R mysql:mysql /var/log/mysql/
 
+# Create `information_schema` and `sys` schemas in Hive
+supervisord -c /etc/supervisord.conf &
+while ! beeline -n hive -e "SELECT 1"; do
+    echo "Waiting for HiveServer2 ..."
+    sleep 10s
+done
+/usr/hdp/current/hive-client/bin/schematool -userName hive -metaDbType mysql -dbType hive -initSchema \
+    -url jdbc:hive2://localhost:10000/default -driver org.apache.hive.jdbc.HiveDriver
+supervisorctl stop all
+
 # Additional libs
 cp -av /usr/hdp/current/hadoop-client/lib/native/Linux-amd64-64/* /usr/lib64/

--- a/prestodev/hdp3.1-hive/files/root/setup.sh
+++ b/prestodev/hdp3.1-hive/files/root/setup.sh
@@ -48,10 +48,10 @@ chown -R mysql:mysql /var/lib/mysql
 /usr/bin/mysqld_safe &
 sleep 10s
 
-cd /usr/hdp/current/hive-metastore/scripts/metastore/upgrade/mysql/
 echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION; FLUSH PRIVILEGES;" | mysql
-echo "CREATE DATABASE metastore; USE metastore; SOURCE hive-schema-3.1.0.mysql.sql;" | mysql
+echo "CREATE DATABASE metastore;" | mysql
 /usr/bin/mysqladmin -u root password 'root'
+/usr/hdp/current/hive-client/bin/schematool -dbType mysql -initSchema
 
 killall mysqld
 sleep 10s

--- a/prestodev/hdp3.1-hive/files/root/setup.sh
+++ b/prestodev/hdp3.1-hive/files/root/setup.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
-# 0 make file system hostname resolvable
+# make file system hostname resolvable
 echo "127.0.0.1 hadoop-master" >> /etc/hosts
 
-# 1 format namenode
+# format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 
 mkdir /usr/hdp/current/hadoop-client/logs /var/log/hadoop-hdfs /var/log/hadoop-yarn
@@ -15,13 +15,13 @@ chmod -R 770 /usr/hdp/current/hadoop-client/logs /var/log/hadoop-hdfs /var/log/h
 rm -f /etc/security/limits.d/hdfs.conf
 su -c "echo 'N' | hdfs namenode -format" hdfs
 
-# 2 start hdfs
+# start hdfs
 su -c "hdfs namenode  2>&1 > /var/log/hadoop-hdfs/hadoop-hdfs-namenode.log" hdfs&
 
-# 3 wait for process starting
+# wait for process starting
 sleep 15
 
-# 4 init basic hdfs directories
+# init basic hdfs directories
 /usr/hdp/current/hadoop-client/libexec/init-hdfs.sh
 
 # 4.1 Create an hdfs home directory for the yarn user. For some reason, init-hdfs doesn't do so.
@@ -30,17 +30,15 @@ su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chmod -R 1777 /tmp/hadoop-yarn'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -mkdir /tmp/hadoop-yarn/staging && /usr/bin/hadoop fs -chown mapred:mapred /tmp/hadoop-yarn/staging && /usr/bin/hadoop fs -chmod -R 1777 /tmp/hadoop-yarn/staging'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -mkdir /tmp/hadoop-yarn/staging/history && /usr/bin/hadoop fs -chown mapred:mapred /tmp/hadoop-yarn/staging/history && /usr/bin/hadoop fs -chmod -R 1777 /tmp/hadoop-yarn/staging/history'
 
-
-
-# 5 init hive directories
+# init hive directories
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -mkdir /user/hive/warehouse'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chmod 1777 /user/hive/warehouse'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chown hive /user/hive/warehouse'
 
-# 6 stop hdfs
+# stop hdfs
 killall java
 
-# 7 setup metastore
+# setup metastore
 mysql_install_db
 
 chown -R mysql:mysql /var/lib/mysql

--- a/prestodev/iop4.2-hive/files/root/setup.sh
+++ b/prestodev/iop4.2-hive/files/root/setup.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
-# 0 make file system hostname resolvable
+# make file system hostname resolvable
 echo "127.0.0.1 hadoop-master" >> /etc/hosts
 
-# 1 format namenode
+# format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 
 # workaround for 'could not open session' bug as suggested here:
@@ -11,25 +11,25 @@ chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 rm -f /etc/security/limits.d/hdfs.conf
 su -c "echo 'N' | hdfs namenode -format" hdfs
 
-# 2 start hdfs
+# start hdfs
 su -c "hdfs datanode  2>&1 > /var/log/hadoop/hdfs/hadoop-hdfs-datanode.log" hdfs&
 su -c "hdfs namenode  2>&1 > /var/log/hadoop/hdfs/hadoop-hdfs-namenode.log" hdfs&
 
-# 3 wait for process starting
+# wait for process starting
 sleep 10
 
 # 4 exec hdfs init script
 /usr/iop/4.2.0.0/hadoop/libexec/init-hdfs.sh
 
-# 5 init hive directories
+# init hive directories
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -mkdir /user/hive/warehouse'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chmod 1777 /user/hive/warehouse'
 su -s /bin/bash hdfs -c '/usr/bin/hadoop fs -chown hive /user/hive/warehouse'
 
-# 6 stop hdfs
+# stop hdfs
 killall java
 
-# 7 setup metastore
+# setup metastore
 mysql_install_db
 
 /usr/bin/mysqld_safe &


### PR DESCRIPTION
Hive 3 has `information_schema` (and `sys`) schemas
(https://issues.apache.org/jira/browse/HIVE-1010).

However, they need to be explicitly "installed".
Installation "instructions" are taken from a bug report
https://jira.apache.org/jira/browse/HIVE-16942.
