### PR TITLE
Use beeline --verbose by default

### DIFF
--- a/prestodev/hdp2.6-hive-kerberized/Dockerfile
+++ b/prestodev/hdp2.6-hive-kerberized/Dockerfile
@@ -96,7 +96,7 @@ RUN set -xeu; \
     for user in root hive hdfs; do \
         sudo -u "${user}" bash -c ' echo "klist -kt /etc/hive/conf/hive.keytab" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop-master@LABS.TERADATA.COM" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop-master:10000/default;principal=hive/hadoop-master@LABS.TERADATA.COM\"" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "beeline --verbose -u \"jdbc:hive2://hadoop-master:10000/default;principal=hive/hadoop-master@LABS.TERADATA.COM\"" >> ~/.bash_history '; \
     done
 
 # EXPOSE KERBEROS PORTS

--- a/prestodev/hdp2.6-hive/Dockerfile
+++ b/prestodev/hdp2.6-hive/Dockerfile
@@ -72,7 +72,7 @@ RUN set -xeu; \
     for user in root hive hdfs; do \
         # ~hive might be owned by root
         chown -R "${user}:" "$(eval echo ~"${user}")"; \
-        sudo -u "${user}" bash -c ' echo "beeline -u jdbc:hive2://localhost:10000/default -n hive" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "beeline --verbose -u jdbc:hive2://localhost:10000/default -n hive" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "hadoop dfs -ls -R /user/hive/warehouse" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' mkdir -p ~/.beeline '; \
         sudo -u "${user}" bash -c ' echo "SELECT current_user();" >> ~/.beeline/history '; \

--- a/prestodev/hdp3.1-hive-kerberized/Dockerfile
+++ b/prestodev/hdp3.1-hive-kerberized/Dockerfile
@@ -96,7 +96,7 @@ RUN set -xeu; \
     for user in root hive hdfs; do \
         sudo -u "${user}" bash -c ' echo "klist -kt /etc/hive/conf/hive.keytab" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop-master@LABS.TERADATA.COM" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop-master:10000/default;principal=hive/hadoop-master@LABS.TERADATA.COM\"" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "beeline --verbose -u \"jdbc:hive2://hadoop-master:10000/default;principal=hive/hadoop-master@LABS.TERADATA.COM\"" >> ~/.bash_history '; \
     done
 
 # EXPOSE KERBEROS PORTS

--- a/prestodev/hdp3.1-hive/Dockerfile
+++ b/prestodev/hdp3.1-hive/Dockerfile
@@ -73,7 +73,7 @@ RUN passwd --unlock root
 # Provide convenience bash history
 RUN set -xeu; \
     for user in root hive hdfs; do \
-        sudo -u "${user}" bash -c ' echo "beeline -n hive" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "beeline --verbose -n hive" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "hdfs dfs -ls -R /user/hive/warehouse" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' mkdir -p ~/.beeline '; \
         sudo -u "${user}" bash -c ' echo "SELECT current_user();" >> ~/.beeline/history '; \


### PR DESCRIPTION
`--verbose` instructs beeline to print full exception stacktrace in case
of query failure.