### PR TITLE
Setup another Kerberized HDP2.6 docker

### DIFF
--- a/prestodev/hdp2.6-hive-kerberized-2/Dockerfile
+++ b/prestodev/hdp2.6-hive-kerberized-2/Dockerfile
@@ -1,0 +1,107 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM prestodev/hdp2.6-hive:unlabelled
+MAINTAINER Presto community <https://prestosql.io/community.html>
+
+# INSTALL KERBEROS
+RUN yum install -y krb5-libs krb5-server krb5-workstation \
+  && yum -y clean all && rm -rf /tmp/* /var/tmp/*
+
+# COPY CONFIGURATION
+COPY ./files /
+
+# CREATE KERBEROS DATABASE
+RUN /usr/sbin/kdb5_util create -s -P password
+
+# CREATE ANOTHER KERBEROS DATABASE
+RUN /usr/sbin/kdb5_util create -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TERADATA.COM -s -P password
+
+# ADD HADOOP PRINCIPALS
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TERADATA.COM"
+
+# CREATE HADOOP KEYTAB FILES
+RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master HTTP/hadoop-master" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop-master HTTP/hadoop-master" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop-master HTTP/hadoop-master" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop-master"
+RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
+  && chown mapred:hadoop /etc/hadoop/conf/mapred.keytab \
+  && chown yarn:hadoop /etc/hadoop/conf/yarn.keytab \
+  && chown hdfs:hadoop /etc/hadoop/conf/HTTP.keytab \
+  && chmod 644 /etc/hadoop/conf/*.keytab
+
+# CREATE HIVE PRINCIPAL AND KEYTAB
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-master"
+RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
+  && chmod 644 /etc/hive/conf/hive.keytab
+
+# CREATE HIVE PRINCIPAL IN THE OTHER REALM
+RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hive/hadoop-master@OTHERLABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hive/conf/hive-other.keytab hive/hadoop-master"
+RUN chown hive:hadoop /etc/hive/conf/hive-other.keytab \
+  && chmod 644 /etc/hive/conf/hive-other.keytab
+
+# CREATE HDFS PRINCIPAL IN OTHER REALM
+RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hdfs/hadoop-master@OTHERLABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hadoop/conf/hdfs-other.keytab hdfs/hadoop-master"
+RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs-other.keytab \
+  && chmod 644 /etc/hadoop/conf/hdfs-other.keytab
+
+# MAKE 'LABS.TERADATA.COM' TRUST 'OTHERLABS.TERADATA.COM'
+RUN /usr/sbin/kadmin.local -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM@OTHERLABS.TERADATA.COM"
+RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM"
+
+# CREATE PRESTO PRINCIPAL AND KEYTAB
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-1.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-2.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/presto-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-client/presto-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/presto-master.docker.cluster@LABS.TERADATA.COM" \
+  && mkdir -p /etc/presto/conf \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/presto/conf/presto-server.keytab presto-server/presto-master.docker.cluster presto-server/presto-worker.docker.cluster presto-server/presto-worker-1.docker.cluster presto-server/presto-worker-2.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/presto/conf/presto-server-HTTP.keytab HTTP/presto-master.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/presto/conf/presto-client.keytab presto-client/presto-master.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/presto/conf/hive-presto-master.keytab hive/presto-master.docker.cluster"
+RUN chmod 644 /etc/presto/conf/*.keytab
+
+# CREATE SSL KEYSTORE
+RUN keytool -genkeypair \
+    -alias presto \
+    -keyalg RSA \
+    -keystore /etc/presto/conf/keystore.jks \
+    -keypass password \
+    -storepass password \
+    -dname "CN=presto-master, OU=, O=, L=, S=, C=" \
+    -validity 100000
+RUN chmod 644 /etc/presto/conf/keystore.jks
+
+# Provide convenience bash history
+RUN set -xeu; \
+    for user in root hive hdfs; do \
+        sudo -u "${user}" bash -c ' echo "klist -kt /etc/hive/conf/hive.keytab" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop-master@LABS.TERADATA.COM" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop-master:10000/default;principal=hive/hadoop-master@LABS.TERADATA.COM\"" >> ~/.bash_history '; \
+    done
+
+# EXPOSE KERBEROS PORTS
+EXPOSE	88
+EXPOSE	89
+EXPOSE	749
+
+CMD supervisord -c /etc/supervisord.conf

--- a/prestodev/hdp2.6-hive-kerberized-2/Dockerfile
+++ b/prestodev/hdp2.6-hive-kerberized-2/Dockerfile
@@ -23,20 +23,17 @@ COPY ./files /
 # CREATE KERBEROS DATABASE
 RUN /usr/sbin/kdb5_util create -s -P password
 
-# CREATE ANOTHER KERBEROS DATABASE
-RUN /usr/sbin/kdb5_util create -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TERADATA.COM -s -P password
-
 # ADD HADOOP PRINCIPALS
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TERADATA.COM"
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master-2@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master-2@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master-2@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master-2@OTHERREALM.COM"
 
 # CREATE HADOOP KEYTAB FILES
-RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop-master"
+RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master-2 HTTP/hadoop-master-2" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop-master-2 HTTP/hadoop-master-2" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop-master-2 HTTP/hadoop-master-2" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop-master-2"
 RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chown mapred:hadoop /etc/hadoop/conf/mapred.keytab \
   && chown yarn:hadoop /etc/hadoop/conf/yarn.keytab \
@@ -44,35 +41,19 @@ RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chmod 644 /etc/hadoop/conf/*.keytab
 
 # CREATE HIVE PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-master"
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master-2@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-master-2"
 RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
   && chmod 644 /etc/hive/conf/hive.keytab
 
-# CREATE HIVE PRINCIPAL IN THE OTHER REALM
-RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hive/hadoop-master@OTHERLABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hive/conf/hive-other.keytab hive/hadoop-master"
-RUN chown hive:hadoop /etc/hive/conf/hive-other.keytab \
-  && chmod 644 /etc/hive/conf/hive-other.keytab
-
-# CREATE HDFS PRINCIPAL IN OTHER REALM
-RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hdfs/hadoop-master@OTHERLABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hadoop/conf/hdfs-other.keytab hdfs/hadoop-master"
-RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs-other.keytab \
-  && chmod 644 /etc/hadoop/conf/hdfs-other.keytab
-
-# MAKE 'LABS.TERADATA.COM' TRUST 'OTHERLABS.TERADATA.COM'
-RUN /usr/sbin/kadmin.local -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM@OTHERLABS.TERADATA.COM"
-RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM"
-
 # CREATE PRESTO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-1.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-2.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-client/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/presto-master.docker.cluster@LABS.TERADATA.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-master.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-1.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-2.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/presto-master.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-client/presto-master.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/presto-master.docker.cluster@OTHERREALM.COM" \
   && mkdir -p /etc/presto/conf \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/presto/conf/presto-server.keytab presto-server/presto-master.docker.cluster presto-server/presto-worker.docker.cluster presto-server/presto-worker-1.docker.cluster presto-server/presto-worker-2.docker.cluster" \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/presto/conf/presto-server-HTTP.keytab HTTP/presto-master.docker.cluster" \
@@ -95,8 +76,8 @@ RUN chmod 644 /etc/presto/conf/keystore.jks
 RUN set -xeu; \
     for user in root hive hdfs; do \
         sudo -u "${user}" bash -c ' echo "klist -kt /etc/hive/conf/hive.keytab" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop-master@LABS.TERADATA.COM" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop-master:10000/default;principal=hive/hadoop-master@LABS.TERADATA.COM\"" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop-master-2@OTHERREALM.COM" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop-master-2:10000/default;principal=hive/hadoop-master-2@OTHERREALM.COM\"" >> ~/.bash_history '; \
     done
 
 # EXPOSE KERBEROS PORTS

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/core-site.xml
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/core-site.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://hadoop-master:9000</value>
+    </property>
+
+    <!-- OOZIE proxy user setting -->
+    <property>
+        <name>hadoop.proxyuser.oozie.hosts</name>
+        <value>*</value>
+    </property>
+    <property>
+        <name>hadoop.proxyuser.oozie.groups</name>
+        <value>*</value>
+    </property>
+
+    <!-- HTTPFS proxy user setting -->
+    <property>
+        <name>hadoop.proxyuser.httpfs.hosts</name>
+        <value>*</value>
+    </property>
+    <property>
+        <name>hadoop.proxyuser.httpfs.groups</name>
+        <value>*</value>
+    </property>
+
+    <!-- Llama proxy user setting -->
+    <property>
+        <name>hadoop.proxyuser.llama.hosts</name>
+        <value>*</value>
+    </property>
+    <property>
+        <name>hadoop.proxyuser.llama.groups</name>
+        <value>*</value>
+    </property>
+
+    <!-- Hue proxy user setting -->
+    <property>
+        <name>hadoop.proxyuser.hue.hosts</name>
+        <value>*</value>
+    </property>
+    <property>
+        <name>hadoop.proxyuser.hue.groups</name>
+        <value>*</value>
+    </property>
+
+    <!-- Mapred proxy user setting -->
+    <property>
+        <name>hadoop.proxyuser.mapred.hosts</name>
+        <value>*</value>
+    </property>
+    <property>
+        <name>hadoop.proxyuser.mapred.groups</name>
+        <value>*</value>
+    </property>
+
+    <!-- Hive impersonation -->
+    <property>
+        <name>hadoop.proxyuser.hive.hosts</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.hive.groups</name>
+        <value>*</value>
+    </property>
+
+    <!-- Hdfs impersonation -->
+    <property>
+        <name>hadoop.proxyuser.hdfs.groups</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.hdfs.hosts</name>
+        <value>*</value>
+    </property>
+
+    <!-- Presto impersonation -->
+    <property>
+        <name>hadoop.proxyuser.presto-server.groups</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.presto-server.hosts</name>
+        <value>*</value>
+    </property>
+
+    <!-- Enable authentication -->
+    <property>
+        <name>hadoop.security.authentication</name>
+        <value>kerberos</value>
+    </property>
+
+    <property>
+        <name>hadoop.security.authorization</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hadoop.security.auth_to_local</name>
+        <value>
+            RULE:[2:$1@$0](.*@OTHERLABS.TERADATA.COM)s/@.*//
+            DEFAULT
+        </value>
+    </property>
+
+</configuration>

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/core-site.xml
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/core-site.xml
@@ -19,7 +19,7 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:9000</value>
+        <value>hdfs://hadoop-master-2:9000</value>
     </property>
 
     <!-- OOZIE proxy user setting -->
@@ -114,14 +114,6 @@
     <property>
         <name>hadoop.security.authorization</name>
         <value>true</value>
-    </property>
-
-    <property>
-        <name>hadoop.security.auth_to_local</name>
-        <value>
-            RULE:[2:$1@$0](.*@OTHERLABS.TERADATA.COM)s/@.*//
-            DEFAULT
-        </value>
     </property>
 
 </configuration>

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/hdfs-site.xml
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/hdfs-site.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<configuration>
+
+    <property>
+        <name>dfs.namenode.name.dir</name>
+        <value>/var/lib/hadoop-hdfs/cache/name/</value>
+    </property>
+
+    <property>
+        <name>dfs.datanode.data.dir</name>
+        <value>/var/lib/hadoop-hdfs/cache/data/</value>
+    </property>
+
+    <!-- General HDFS security config -->
+    <property>
+        <name>dfs.block.access.token.enable</name>
+        <value>true</value>
+    </property>
+
+    <!-- NameNode security config -->
+    <property>
+        <name>dfs.namenode.keytab.file</name>
+        <value>/etc/hadoop/conf/hdfs.keytab</value> <!-- path to the HDFS keytab -->
+    </property>
+    <property>
+        <name>dfs.namenode.kerberos.principal</name>
+        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+    </property>
+    <property>
+        <name>dfs.namenode.kerberos.internal.spnego.principal</name>
+        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+    </property>
+
+    <!-- Secondary NameNode security config -->
+    <property>
+        <name>dfs.secondary.namenode.keytab.file</name>
+        <value>/etc/hadoop/conf/hdfs.keytab</value> <!-- path to the HDFS keytab -->
+    </property>
+    <property>
+        <name>dfs.secondary.namenode.kerberos.principal</name>
+        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+    </property>
+    <property>
+        <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
+        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+    </property>
+
+    <!-- DataNode security config -->
+    <property>
+        <name>dfs.datanode.keytab.file</name>
+        <value>/etc/hadoop/conf/hdfs.keytab</value> <!-- path to the HDFS keytab -->
+    </property>
+    <property>
+        <name>dfs.datanode.kerberos.principal</name>
+        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+    </property>
+
+    <!-- WebHDFS security config -->
+    <property>
+        <name>dfs.webhdfs.enabled</name>
+        <value>true</value>
+    </property>
+
+    <!-- Web Authentication config -->
+    <property>
+        <name>dfs.web.authentication.kerberos.principal</name>
+        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+    </property>
+
+    <property>
+        <name>dfs.web.authentication.kerberos.keytab</name>
+        <value>/etc/hadoop/conf/HTTP.keytab</value> <!-- path to the HTTP keytab -->
+    </property>
+
+    <property>
+        <name>ignore.secure.ports.for.testing</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>dfs.http.policy</name>
+        <value>HTTP_ONLY</value>
+    </property>
+
+</configuration>

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/hdfs-site.xml
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/hdfs-site.xml
@@ -38,11 +38,11 @@
     </property>
     <property>
         <name>dfs.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master-2@OTHERREALM.COM</value>
     </property>
     <property>
         <name>dfs.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master-2@OTHERREALM.COM</value>
     </property>
 
     <!-- Secondary NameNode security config -->
@@ -52,11 +52,11 @@
     </property>
     <property>
         <name>dfs.secondary.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master-2@OTHERREALM.COM</value>
     </property>
     <property>
         <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master-2@OTHERREALM.COM</value>
     </property>
 
     <!-- DataNode security config -->
@@ -66,7 +66,7 @@
     </property>
     <property>
         <name>dfs.datanode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master-2@OTHERREALM.COM</value>
     </property>
 
     <!-- WebHDFS security config -->
@@ -78,7 +78,7 @@
     <!-- Web Authentication config -->
     <property>
         <name>dfs.web.authentication.kerberos.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master-2@OTHERREALM.COM</value>
     </property>
 
     <property>

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/mapred-site.xml
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/mapred-site.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+
+    <property>
+        <name>mapred.job.tracker</name>
+        <value>hadoop-master:8021</value>
+    </property>
+
+    <property>
+        <name>mapreduce.framework.name</name>
+        <value>yarn</value>
+    </property>
+
+    <property>
+        <name>mapreduce.jobhistory.address</name>
+        <value>hadoop-master:10020</value>
+    </property>
+
+    <property>
+        <name>mapreduce.jobhistory.webapp.address</name>
+        <value>hadoop-master:19888</value>
+    </property>
+
+    <property>
+        <description>To set the value of tmp directory for map and reduce tasks.</description>
+        <name>mapreduce.task.tmp.dir</name>
+        <value>/var/lib/hadoop-mapreduce/cache/${user.name}/tasks</value>
+    </property>
+
+    <!-- MapReduce Job History Server security configs -->
+    <property>
+        <name>mapreduce.jobhistory.keytab</name>
+        <value>/etc/hadoop/conf/mapred.keytab</value>    <!-- path to the MAPRED keytab for the Job History Server -->
+    </property>
+
+    <property>
+        <name>mapreduce.jobhistory.principal</name>
+        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+    </property>
+
+    <!-- JobTracker security configs -->
+    <property>
+        <name>mapreduce.jobtracker.kerberos.principal</name>
+        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+    </property>
+
+    <property>
+        <name>mapreduce.jobtracker.keytab.file</name>
+        <value>/etc/hadoop/conf/mapred.keytab</value> <!-- path to the MapReduce keytab -->
+    </property>
+
+    <!-- TaskTracker security configs -->
+    <property>
+        <name>mapreduce.tasktracker.kerberos.principal</name>
+        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+    </property>
+
+    <property>
+        <name>mapreduce.tasktracker.keytab.file</name>
+        <value>/etc/hadoop/conf/mapred.keytab</value> <!-- path to the MapReduce keytab -->
+    </property>
+
+</configuration>

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/mapred-site.xml
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/mapred-site.xml
@@ -19,7 +19,7 @@
 
     <property>
         <name>mapred.job.tracker</name>
-        <value>hadoop-master:8021</value>
+        <value>hadoop-master-2:8021</value>
     </property>
 
     <property>
@@ -29,12 +29,12 @@
 
     <property>
         <name>mapreduce.jobhistory.address</name>
-        <value>hadoop-master:10020</value>
+        <value>hadoop-master-2:10020</value>
     </property>
 
     <property>
         <name>mapreduce.jobhistory.webapp.address</name>
-        <value>hadoop-master:19888</value>
+        <value>hadoop-master-2:19888</value>
     </property>
 
     <property>
@@ -51,13 +51,13 @@
 
     <property>
         <name>mapreduce.jobhistory.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master-2@OTHERREALM.COM</value>
     </property>
 
     <!-- JobTracker security configs -->
     <property>
         <name>mapreduce.jobtracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master-2@OTHERREALM.COM</value>
     </property>
 
     <property>
@@ -68,7 +68,7 @@
     <!-- TaskTracker security configs -->
     <property>
         <name>mapreduce.tasktracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master-2@OTHERREALM.COM</value>
     </property>
 
     <property>

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/yarn-site.xml
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/yarn-site.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<configuration>
+
+    <property>
+        <name>yarn.nodemanager.aux-services</name>
+        <value>mapreduce_shuffle</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.aux-services.mapreduce_shuffle.class</name>
+        <value>org.apache.hadoop.mapred.ShuffleHandler</value>
+    </property>
+
+    <property>
+        <name>yarn.log-aggregation-enable</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>yarn.dispatcher.exit-on-error</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <description>List of directories to store localized files in.</description>
+        <name>yarn.nodemanager.local-dirs</name>
+        <value>/var/lib/hadoop-yarn/cache/${user.name}/nm-local-dir</value>
+    </property>
+
+    <property>
+        <description>Where to store container logs.</description>
+        <name>yarn.nodemanager.log-dirs</name>
+        <value>/var/log/hadoop-yarn/containers</value>
+    </property>
+
+    <property>
+        <description>Where to aggregate logs to.</description>
+        <name>yarn.nodemanager.remote-app-log-dir</name>
+        <value>/var/log/hadoop-yarn/apps</value>
+    </property>
+
+    <property>
+        <description>Classpath for typical applications.</description>
+        <name>yarn.application.classpath</name>
+        <value>
+            /etc/hadoop/conf,
+            /usr/hdp/current/hadoop-client/*,
+            /usr/hdp/current/hadoop-client/lib/*,
+            /usr/hdp/current/hadoop-hdfs-client/*,
+            /usr/hdp/current/hadoop-hdfs-client/lib/*,
+            /usr/hdp/current/hadoop-yarn-client/*,
+            /usr/hdp/current/hadoop-yarn-client/lib/*,
+            /usr/hdp/current/hadoop-mapreduce-client/*,
+            /usr/hdp/current/hadoop-mapreduce-client/lib/*
+        </value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.hostname</name>
+        <value>hadoop-master</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.disk-health-checker.max-disk-utilization-per-disk-percentage</name>
+        <value>100</value>
+    </property>
+
+    <property>
+        <name>yarn.log.server.url</name>
+        <value>http://hadoop-master:19888/jobhistory/logs</value>
+    </property>
+
+    <!-- ResourceManager security configs -->
+    <property>
+        <name>yarn.resourcemanager.keytab</name>
+        <value>/etc/hadoop/conf/yarn.keytab</value>    <!-- path to the YARN keytab -->
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.principal</name>
+        <value>yarn/hadoop-master@LABS.TERADATA.COM</value>
+    </property>
+
+    <!-- NodeManager security configs -->
+    <property>
+        <name>yarn.nodemanager.keytab</name>
+        <value>/etc/hadoop/conf/yarn.keytab</value>    <!-- path to the YARN keytab -->
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.principal</name>
+        <value>yarn/hadoop-master@LABS.TERADATA.COM</value>
+    </property>
+
+</configuration>

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/yarn-site.xml
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/hadoop/conf/yarn-site.xml
@@ -74,7 +74,7 @@
 
     <property>
         <name>yarn.resourcemanager.hostname</name>
-        <value>hadoop-master</value>
+        <value>hadoop-master-2</value>
     </property>
 
     <property>
@@ -84,7 +84,7 @@
 
     <property>
         <name>yarn.log.server.url</name>
-        <value>http://hadoop-master:19888/jobhistory/logs</value>
+        <value>http://hadoop-master-2:19888/jobhistory/logs</value>
     </property>
 
     <!-- ResourceManager security configs -->
@@ -95,7 +95,7 @@
 
     <property>
         <name>yarn.resourcemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TERADATA.COM</value>
+        <value>yarn/hadoop-master-2@OTHERREALM.COM</value>
     </property>
 
     <!-- NodeManager security configs -->
@@ -106,7 +106,7 @@
 
     <property>
         <name>yarn.nodemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TERADATA.COM</value>
+        <value>yarn/hadoop-master-2@OTHERREALM.COM</value>
     </property>
 
 </configuration>

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/hive/conf/hive-site.xml
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/hive/conf/hive-site.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+
+    <property>
+        <name>javax.jdo.option.ConnectionURL</name>
+        <value>jdbc:mysql://localhost/metastore</value>
+        <description>the URL of the MySQL database</description>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionDriverName</name>
+        <value>com.mysql.jdbc.Driver</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionUserName</name>
+        <value>root</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionPassword</name>
+        <value>root</value>
+    </property>
+
+    <property>
+        <name>datanucleus.autoCreateSchema</name>
+        <value>false</value>
+    </property>
+
+    <property>
+        <name>datanucleus.fixedDatastore</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>datanucleus.autoStartMechanism</name>
+        <value>SchemaTable</value>
+    </property>
+
+    <property>
+        <name>hive.security.authorization.createtable.owner.grants</name>
+        <value>ALL</value>
+        <description>The set of privileges automatically granted to the owner whenever a table gets created.</description>
+    </property>
+
+    <property>
+        <name>hive.users.in.admin.role</name>
+        <value>hdfs,hive</value>
+    </property>
+
+    <!-- Enable authentication -->
+    <property>
+        <name>hive.server2.authentication</name>
+        <value>KERBEROS</value>
+    </property>
+
+    <property>
+        <name>hive.server2.enable.impersonation</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hive.server2.authentication.kerberos.principal</name>
+        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+    </property>
+
+    <property>
+        <name>hive.server2.authentication.kerberos.keytab</name>
+        <value>/etc/hive/conf/hive.keytab</value>
+    </property>
+
+    <property>
+        <name>hive.metastore.sasl.enabled</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hive.metastore.kerberos.keytab.file</name>
+        <value>/etc/hive/conf/hive.keytab</value>
+    </property>
+
+    <property>
+        <name>hive.metastore.kerberos.principal</name>
+        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+    </property>
+
+    <!-- Enable SQL based authorization -->
+    <property>
+        <name>hive.security.authorization.manager</name>
+        <value>org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdConfOnlyAuthorizerFactory</value>
+    </property>
+
+    <property>
+        <name>hive.security.authorization.task.factory</name>
+        <value>org.apache.hadoop.hive.ql.parse.authorization.HiveAuthorizationTaskFactoryImpl</value>
+    </property>
+
+</configuration>

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/hive/conf/hive-site.xml
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/hive/conf/hive-site.xml
@@ -77,7 +77,7 @@
 
     <property>
         <name>hive.server2.authentication.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hive/hadoop-master-2@OTHERREALM.COM</value>
     </property>
 
     <property>
@@ -97,7 +97,7 @@
 
     <property>
         <name>hive.metastore.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hive/hadoop-master-2@OTHERREALM.COM</value>
     </property>
 
     <!-- Enable SQL based authorization -->

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/hive/conf/hiveserver2-site.xml
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/hive/conf/hiveserver2-site.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+
+    <!-- Enable authentication -->
+    <property>
+        <name>hive.security.authenticator.manager</name>
+        <value>org.apache.hadoop.hive.ql.security.SessionStateUserAuthenticator</value>
+    </property>
+
+    <!-- Enable authorization -->
+    <property>
+        <name>hive.security.authorization.manager</name>
+        <value>org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory</value>
+        <description>SQL standards based Hive authorization</description>
+    </property>
+
+    <property>
+        <name>hive.security.authorization.enabled</name>
+        <value>true</value>
+    </property>
+
+</configuration>

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/krb5.conf
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/krb5.conf
@@ -1,0 +1,22 @@
+[logging]
+ default = FILE:/var/log/krb5libs.log
+ kdc = FILE:/var/log/krb5kdc.log
+ admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+ default_realm = LABS.TERADATA.COM
+ dns_lookup_realm = false
+ dns_lookup_kdc = false
+ ticket_lifetime = 24h
+ renew_lifetime = 7d
+ forwardable = true
+
+[realms]
+ LABS.TERADATA.COM = {
+  kdc = hadoop-master:88
+  admin_server = hadoop-master
+ }
+ OTHERLABS.TERADATA.COM = {
+  kdc = hadoop-master:89
+  admin_server = hadoop-master
+ }

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/krb5.conf
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/krb5.conf
@@ -4,7 +4,7 @@
  admin_server = FILE:/var/log/kadmind.log
 
 [libdefaults]
- default_realm = LABS.TERADATA.COM
+ default_realm = OTHERREALM.COM
  dns_lookup_realm = false
  dns_lookup_kdc = false
  ticket_lifetime = 24h
@@ -12,11 +12,7 @@
  forwardable = true
 
 [realms]
- LABS.TERADATA.COM = {
-  kdc = hadoop-master:88
-  admin_server = hadoop-master
- }
- OTHERLABS.TERADATA.COM = {
-  kdc = hadoop-master:89
-  admin_server = hadoop-master
+ OTHERREALM.COM = {
+  kdc = hadoop-master-2:88
+  admin_server = hadoop-master-2
  }

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/supervisord.d/kdc.conf
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/supervisord.d/kdc.conf
@@ -1,0 +1,15 @@
+[program:krb5kdc]
+command=/bin/bash -c "exec /usr/sbin/krb5kdc -P /var/run/krb5kdc.pid -n -r LABS.TERADATA.COM -n -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TERADATA.COM"
+autostart=true
+autorestart=true
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+
+[program:kadmind]
+command=/bin/bash -c "exec /usr/sbin/kadmind -P /var/run/kadmind.pid -nofork -r LABS.TERADATA.COM"
+autostart=true
+autorestart=true
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0

--- a/prestodev/hdp2.6-hive-kerberized-2/files/etc/supervisord.d/kdc.conf
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/etc/supervisord.d/kdc.conf
@@ -1,5 +1,5 @@
 [program:krb5kdc]
-command=/bin/bash -c "exec /usr/sbin/krb5kdc -P /var/run/krb5kdc.pid -n -r LABS.TERADATA.COM -n -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TERADATA.COM"
+command=/bin/bash -c "exec /usr/sbin/krb5kdc -P /var/run/krb5kdc.pid -n -r OTHERREALM.COM"
 autostart=true
 autorestart=true
 redirect_stderr=true
@@ -7,7 +7,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:kadmind]
-command=/bin/bash -c "exec /usr/sbin/kadmind -P /var/run/kadmind.pid -nofork -r LABS.TERADATA.COM"
+command=/bin/bash -c "exec /usr/sbin/kadmind -P /var/run/kadmind.pid -nofork -r OTHERREALM.COM"
 autostart=true
 autorestart=true
 redirect_stderr=true

--- a/prestodev/hdp2.6-hive-kerberized-2/files/var/kerberos/krb5kdc/kadm5-other.acl
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/var/kerberos/krb5kdc/kadm5-other.acl
@@ -1,0 +1,1 @@
+*/admin@OTHERLABS.TERADATA.COM *

--- a/prestodev/hdp2.6-hive-kerberized-2/files/var/kerberos/krb5kdc/kadm5-other.acl
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/var/kerberos/krb5kdc/kadm5-other.acl
@@ -1,1 +1,0 @@
-*/admin@OTHERLABS.TERADATA.COM *

--- a/prestodev/hdp2.6-hive-kerberized-2/files/var/kerberos/krb5kdc/kadm5.acl
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/var/kerberos/krb5kdc/kadm5.acl
@@ -1,0 +1,1 @@
+*/admin@LABS.TERADATA.COM	*

--- a/prestodev/hdp2.6-hive-kerberized-2/files/var/kerberos/krb5kdc/kadm5.acl
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/var/kerberos/krb5kdc/kadm5.acl
@@ -1,1 +1,1 @@
-*/admin@LABS.TERADATA.COM	*
+*/admin@OTHERREALM.COM	*

--- a/prestodev/hdp2.6-hive-kerberized-2/files/var/kerberos/krb5kdc/kdc.conf
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/var/kerberos/krb5kdc/kdc.conf
@@ -1,0 +1,23 @@
+[kdcdefaults]
+ kdc_ports = 88
+ kdc_tcp_ports = 88
+
+[realms]
+ LABS.TERADATA.COM = {
+  acl_file = /var/kerberos/krb5kdc/kadm5.acl
+  dict_file = /usr/share/dict/words
+  admin_keytab = /var/kerberos/krb5kdc/kadm5.keytab
+  supported_enctypes = aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
+ }
+
+ OTHERLABS.TERADATA.COM = {
+  acl_file = /var/kerberos/krb5kdc/kadm5-other.acl
+  dict_file = /usr/share/dict/words
+  admin_keytab = /var/kerberos/krb5kdc/kadm5-other.keytab
+  supported_enctypes = aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
+  kdc_listen = 89
+  kdc_tcp_listen = 89
+  kdc_ports = 89
+  kdc_tcp_ports = 89
+ }
+

--- a/prestodev/hdp2.6-hive-kerberized-2/files/var/kerberos/krb5kdc/kdc.conf
+++ b/prestodev/hdp2.6-hive-kerberized-2/files/var/kerberos/krb5kdc/kdc.conf
@@ -3,21 +3,9 @@
  kdc_tcp_ports = 88
 
 [realms]
- LABS.TERADATA.COM = {
+ OTHERREALM.COM = {
   acl_file = /var/kerberos/krb5kdc/kadm5.acl
   dict_file = /usr/share/dict/words
   admin_keytab = /var/kerberos/krb5kdc/kadm5.keytab
   supported_enctypes = aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
  }
-
- OTHERLABS.TERADATA.COM = {
-  acl_file = /var/kerberos/krb5kdc/kadm5-other.acl
-  dict_file = /usr/share/dict/words
-  admin_keytab = /var/kerberos/krb5kdc/kadm5-other.keytab
-  supported_enctypes = aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
-  kdc_listen = 89
-  kdc_tcp_listen = 89
-  kdc_ports = 89
-  kdc_tcp_ports = 89
- }
-


### PR DESCRIPTION
Setup another Kerberized HDP2.6 docker

This is useful when testing connection two differently kerberized
Hive servers from single Presto instance.
