### PR TITLE
Add debugging instructions for Hive metastore

### DIFF
--- a/prestodev/cdh5.12-hive/files/etc/supervisord.d/hive-metastore.conf
+++ b/prestodev/cdh5.12-hive/files/etc/supervisord.d/hive-metastore.conf
@@ -1,4 +1,5 @@
 [program:hive-metastore]
+# Add `--debug:port=5006` for debugging
 command=hive --service metastore
 startsecs=2
 stopwaitsecs=10

--- a/prestodev/cdh5.15-hive/files/etc/supervisord.d/hive-metastore.conf
+++ b/prestodev/cdh5.15-hive/files/etc/supervisord.d/hive-metastore.conf
@@ -1,4 +1,5 @@
 [program:hive-metastore]
+# Add `--debug:port=5006` for debugging
 command=hive --service metastore
 startsecs=2
 stopwaitsecs=10

--- a/prestodev/hdp2.5-hive/files/etc/supervisord.d/hive-metastore.conf
+++ b/prestodev/hdp2.5-hive/files/etc/supervisord.d/hive-metastore.conf
@@ -1,4 +1,5 @@
 [program:hive-metastore]
+# Add `--debug:port=5006` for debugging
 command=hive --service metastore
 startsecs=2
 stopwaitsecs=10

--- a/prestodev/hdp2.6-hive/files/etc/supervisord.d/hive-metastore.conf
+++ b/prestodev/hdp2.6-hive/files/etc/supervisord.d/hive-metastore.conf
@@ -1,4 +1,5 @@
 [program:hive-metastore]
+# Add `--debug:port=5006` for debugging
 command=hive --service metastore
 startsecs=2
 stopwaitsecs=10

--- a/prestodev/hdp3.1-hive/files/etc/supervisord.d/hive-metastore.conf
+++ b/prestodev/hdp3.1-hive/files/etc/supervisord.d/hive-metastore.conf
@@ -1,4 +1,5 @@
 [program:hive-metastore]
+# Add `--debug:port=5006` for debugging
 command=hive --service metastore
 startsecs=2
 stopwaitsecs=10


### PR DESCRIPTION
This is useful. Alternative obvious approach with setting `HADOOP_OPT`
requires manual modifications in the `hive` launcher script.