### PR TITLE
Disable physical memory checks for HDP3.1

### DIFF
--- a/prestodev/hdp3.1-hive/files/etc/hadoop/conf/yarn-site.xml
+++ b/prestodev/hdp3.1-hive/files/etc/hadoop/conf/yarn-site.xml
@@ -93,6 +93,12 @@
         <description>Whether virtual memory limits will be enforced for containers.</description>
     </property>
 
+    <property>
+        <name>yarn.nodemanager.pmem-check-enabled</name>
+        <value>false</value>
+        <description>Whether physical memory limits will be enforced for containers.</description>
+    </property>
+
     <!-- Minimum container memory, default value is 1024 which is too high for the test queries -->
     <property>
         <name>yarn.scheduler.minimum-allocation-mb</name>


### PR DESCRIPTION
That will prevent from containers being killed when they exceed physical memory limits and will (probably) remove some of the flakiness.