### PR TITLE
Add original hostname to etc/hosts file for Greenplum

### DIFF
--- a/prestodev/gpdb-6/Dockerfile
+++ b/prestodev/gpdb-6/Dockerfile
@@ -39,6 +39,7 @@ RUN adduser --home /home/gpadmin gpadmin --disabled-password --gecos GECOS && \
     # Start SSH service and initialize GPDB
     service ssh start && \
     su gpadmin -l -c configure_gpdb.sh && \
+    hostname > ~/original_hostname && \
     # Allow client access from any host
     echo "host all all 0.0.0.0/0 md5" >> /gpmaster/gpsne-1/pg_hba.conf
 

--- a/prestodev/gpdb-6/files/usr/local/bin/entrypoint.sh
+++ b/prestodev/gpdb-6/files/usr/local/bin/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "127.0.0.1 $(cat ~/original_hostname)" >> /etc/hosts
+
 service ssh start
 su gpadmin -l -c "export MASTER_DATA_DIRECTORY=/gpmaster/gpsne-1 ; source ${GPHOME}/greenplum_path.sh ; gpstart -a ; createdb ${DATABASE}"
 tail -f /gpmaster/gpsne-1/pg_log/gpdb-*.csv


### PR DESCRIPTION
Greenplum keeps track of the hostname in the metadata after initialization,
which can cause some issues as the hostnames change between Docker containers.
Here we add the original hostname when GPDB was initialized and add it to
/etc/hosts on startup so it can resolve that hostname.