### PR TITLE
Add Accumulo Docker image

### DIFF
--- a/prestodev/accumulo/Dockerfile
+++ b/prestodev/accumulo/Dockerfile
@@ -1,0 +1,95 @@
+FROM prestodev/centos6-oj8:unlabelled
+
+ARG ACCUMULO_VERSION=1.7.4
+ARG HADOOP_VERSION=2.6.5
+ARG ZOOKEEPER_VERSION=3.4.14
+ARG IMAGE_ROOT_INSTALL=/usr/local/lib
+
+ENV HADOOP_HOME=$IMAGE_ROOT_INSTALL/hadoop
+ENV ACCUMULO_HOME=$IMAGE_ROOT_INSTALL/accumulo
+ENV ZOOKEEPER_HOME=$IMAGE_ROOT_INSTALL/zookeeper
+
+ARG HADOOP_CONF=$HADOOP_HOME/conf
+ENV HADOOP_PREFIX=$HADOOP_HOME
+
+# TODO Apache Archive is rate limited -- these should probably go in S3
+ARG BASE_URL=https://archive.apache.org/dist
+ARG ACCUMULO_BINARY_PATH=$BASE_URL/accumulo/$ACCUMULO_VERSION/accumulo-$ACCUMULO_VERSION-bin.tar.gz
+ARG HADOOP_BINARY_PATH=$BASE_URL/hadoop/core/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz
+ARG ZOOKEEPER_BINARY_PATH=$BASE_URL/zookeeper/zookeeper-$ZOOKEEPER_VERSION/zookeeper-$ZOOKEEPER_VERSION.tar.gz
+
+RUN yum update -y && \
+    yum install -y gettext && \
+    yum clean all -y
+
+RUN mkdir -p $IMAGE_ROOT_INSTALL
+
+# Download Hadoop
+RUN wget --quiet $HADOOP_BINARY_PATH && \
+    tar -xf hadoop-$HADOOP_VERSION.tar.gz -C $IMAGE_ROOT_INSTALL  && \
+    rm hadoop-$HADOOP_VERSION.tar.gz && \
+    ln -s $IMAGE_ROOT_INSTALL/hadoop-$HADOOP_VERSION $HADOOP_HOME
+
+# Download Accumulo
+RUN wget --quiet $ACCUMULO_BINARY_PATH && \
+    tar -xf accumulo-$ACCUMULO_VERSION-bin.tar.gz -C $IMAGE_ROOT_INSTALL && \
+    rm accumulo-$ACCUMULO_VERSION-bin.tar.gz && \
+    ln -s $IMAGE_ROOT_INSTALL/accumulo-$ACCUMULO_VERSION $ACCUMULO_HOME
+
+# Copy sample Accumulo configuration files and update the instance.volumes property
+ENV CONF_SAMPLE_DIR=$ACCUMULO_HOME/conf/examples/3GB/standalone
+RUN cp \
+    $CONF_SAMPLE_DIR/accumulo-env.sh \
+    $CONF_SAMPLE_DIR/accumulo-site.xml \
+    $CONF_SAMPLE_DIR/auditLog.xml \
+    $CONF_SAMPLE_DIR/generic_logger.properties \
+    $CONF_SAMPLE_DIR/generic_logger.xml \
+    $CONF_SAMPLE_DIR/log4j.properties \
+    $CONF_SAMPLE_DIR/monitor_logger.properties \
+    $CONF_SAMPLE_DIR/monitor_logger.xml \
+    $ACCUMULO_HOME/conf && \
+    sed -i s/"<value><\/value>"/"<value>file:\/\/\/tmp\/accumulo<\/value>"/ $ACCUMULO_HOME/conf/accumulo-site.xml
+
+# Download Presto Accumulo Iterators
+RUN wget --quiet https://repo1.maven.org/maven2/io/prestosql/presto-accumulo-iterators/344/presto-accumulo-iterators-344.jar && \
+    mkdir -p $ACCUMULO_HOME/lib/ext && \
+    mv presto-accumulo-iterators-344.jar $ACCUMULO_HOME/lib/ext
+
+# Download ZooKeeper
+RUN wget --quiet $ZOOKEEPER_BINARY_PATH && \
+    tar -xf zookeeper-$ZOOKEEPER_VERSION.tar.gz -C $IMAGE_ROOT_INSTALL && \
+    rm zookeeper-$ZOOKEEPER_VERSION.tar.gz && \
+    ln -s $IMAGE_ROOT_INSTALL/zookeeper-$ZOOKEEPER_VERSION $ZOOKEEPER_HOME && \
+    cp $ZOOKEEPER_HOME/conf/zoo_sample.cfg $ZOOKEEPER_HOME/conf/zoo.cfg
+
+RUN mkdir -p /var/log/zookeeper /var/log/accumulo
+
+COPY ./files /
+
+# Initialize Accumulo which requires ZooKeeper to be started
+RUN ${ZOOKEEPER_HOME}/bin/zkServer.sh start && \
+    ${ACCUMULO_HOME}/bin/accumulo init --user root --password secret --instance-name default
+
+# ZooKeeper
+EXPOSE 2181
+# Accumulo Monitor
+EXPOSE 50095
+# Accumulo Monitor Logs
+EXPOSE 4560
+# Accumulo TabletServer
+EXPOSE 9997
+# Accumulo TabletServer Replication Service
+EXPOSE 10002
+# Accumulo GC
+EXPOSE 50091
+# Accumulo Master
+EXPOSE 9999
+# Accumulo Replication Service
+EXPOSE 10001
+# Accumulo Tracer
+EXPOSE 12234
+
+ENTRYPOINT ADDRESS=`hostname -I` supervisord -c /etc/supervisord.conf
+
+HEALTHCHECK --start-period=5m \
+  CMD $ACCUMULO_HOME/bin/accumulo org.apache.accumulo.server.util.ListInstances | grep default

--- a/prestodev/accumulo/files/etc/supervisord.conf
+++ b/prestodev/accumulo/files/etc/supervisord.conf
@@ -1,0 +1,22 @@
+[supervisord]
+logfile = /var/log/supervisord.log
+logfile_maxbytes = 50MB
+logfile_backups=10
+loglevel = info
+pidfile = /var/run/supervisord.pid
+nodaemon = true
+directory = /tmp
+strip_ansi = false
+user=root
+
+[unix_http_server]
+file = /tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl = unix:///tmp/supervisor.sock
+
+[include]
+files = /etc/supervisord.d/*.conf

--- a/prestodev/accumulo/files/etc/supervisord.d/accumulo-gc.conf
+++ b/prestodev/accumulo/files/etc/supervisord.d/accumulo-gc.conf
@@ -1,0 +1,8 @@
+[program:accumulo-gc]
+command=/usr/local/lib/accumulo/bin/accumulo gc --address %(ENV_ADDRESS)s
+startsecs=2
+stopwaitsecs=10
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/accumulo/gc.log
+autostart=true

--- a/prestodev/accumulo/files/etc/supervisord.d/accumulo-master.conf
+++ b/prestodev/accumulo/files/etc/supervisord.d/accumulo-master.conf
@@ -1,0 +1,8 @@
+[program:accumulo-master]
+command=/usr/local/lib/accumulo/bin/accumulo master --address %(ENV_ADDRESS)s
+startsecs=2
+stopwaitsecs=10
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/accumulo/master.log
+autostart=true

--- a/prestodev/accumulo/files/etc/supervisord.d/accumulo-monitor.conf
+++ b/prestodev/accumulo/files/etc/supervisord.d/accumulo-monitor.conf
@@ -1,0 +1,8 @@
+[program:accumulo-monitor]
+command=/usr/local/lib/accumulo/bin/accumulo monitor --address %(ENV_ADDRESS)s
+startsecs=2
+stopwaitsecs=10
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/accumulo/monitor.log
+autostart=true

--- a/prestodev/accumulo/files/etc/supervisord.d/accumulo-tracer.conf
+++ b/prestodev/accumulo/files/etc/supervisord.d/accumulo-tracer.conf
@@ -1,0 +1,8 @@
+[program:accumulo-tracer]
+command=/usr/local/lib/accumulo/bin/accumulo tracer --address %(ENV_ADDRESS)s
+startsecs=2
+stopwaitsecs=10
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/accumulo/tracer.log
+autostart=true

--- a/prestodev/accumulo/files/etc/supervisord.d/accumulo-tserver.conf
+++ b/prestodev/accumulo/files/etc/supervisord.d/accumulo-tserver.conf
@@ -1,0 +1,8 @@
+[program:accumulo-tserver]
+command=/usr/local/lib/accumulo/bin/accumulo tserver --address %(ENV_ADDRESS)s
+startsecs=2
+stopwaitsecs=10
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/accumulo/tserver.log
+autostart=true

--- a/prestodev/accumulo/files/etc/supervisord.d/zookeeper.conf
+++ b/prestodev/accumulo/files/etc/supervisord.d/zookeeper.conf
@@ -1,0 +1,8 @@
+[program:zookeeper]
+command=/usr/local/lib/zookeeper/bin/zkServer.sh start-foreground
+startsecs=2
+stopwaitsecs=10
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/zookeeper/zookeeper.log
+autostart=true


### PR DESCRIPTION
This commit adds an Accumulo 1.10.0 Docker image in order to remove the dependency on MiniAccumuloCluster in the presto-accumulo unit tests. It runs ZooKeeper and all five Accumulo services in the same container. While it isn't the "Docker way" to have multiple services in one container, it greatly simplifies use.